### PR TITLE
Scrapelist show page styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,3 +17,4 @@ $spotify: #1FD760;
 @import 'pagesStyling/home';
 @import 'pagesStyling/choice_page';
 @import 'pagesStyling/easy_genre_form';
+@import 'pagesStyling/show_scrapelist';

--- a/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
+++ b/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
@@ -61,6 +61,13 @@
             padding: 1.5em 1.7em;
             background-color: $spotify;
             border-radius: 3em;
+            box-shadow: -4px 4px 5px rgba(0, 0, 0, 0.3);
+            transition: 0.2s;
+            &:hover {
+              background-color: #3BE376;
+              outline: 1px solid $spotify;
+              box-shadow: none;
+            }
           }
         }
       }
@@ -78,7 +85,7 @@
         background-color: $darkblue;
         border-radius: 0.5em;
         overflow-y: auto;
-        .song-card-link-wrapper {
+        .song-card-link-wrapper { // remove default styling from rails link_to tag
           text-decoration: none;
           color: $black;
         }
@@ -92,6 +99,12 @@
           display: flex;
           justify-content: space-between;
           align-items: center;
+          transition: 0.2s;
+          &:hover {
+            background-color: $bandcamp;
+            color: white;
+            outline: 3px solid #9F2D71;
+          }
           .song-art-container {
             width: 20%;
             height: 100%;

--- a/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
+++ b/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
@@ -76,6 +76,7 @@
         height: 90%;
         margin: auto;
         background-color: $darkblue;
+        border-radius: 0.5em;
         overflow-y: auto;
         .song-card {
           width: 89%;
@@ -83,6 +84,7 @@
           margin: 4% auto;
           padding: 1.5%;
           background-color: #d9d9d9;
+          border-radius: 0.5em;
           display: flex;
           justify-content: space-between;
           align-items: center;

--- a/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
+++ b/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
@@ -1,0 +1,43 @@
+.show-wrapper {
+  width: 100dvw;
+  height: 100dvh;
+  background-color: $pink;
+  display: flex;
+  align-items: center;
+  .show-container {
+    width: 70%;
+    height: 78%;
+    margin: auto;
+    background-color: white;
+    display: flex;
+    justify-content: space-between;
+    .text-wrapper {
+      width: 50%;
+      height: 100%;
+      background-color: blue;
+      .show-title {
+        width: 100%;
+        height: 10%;
+        color: black;
+        background-color: green;
+      }
+      .show-explanation {
+        width: 100%;
+        height: 40%;
+        color: black;
+        background-color: yellow;
+      }
+      .show-spotify-btn {
+        width: 100%;
+        height: 20%;
+        color: black;
+        background-color: orange;
+      }
+    }
+    .songs-container {
+      width: 50%;
+      height: 100%;
+      background-color: red;
+    }
+  }
+}

--- a/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
+++ b/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
@@ -35,7 +35,7 @@
         .show-explanation {
           height: fit-content;
           margin: 0;
-          padding: 5%;
+          padding: 5% 5% 0 5%;
           color: $black;
           text-align: center;
           font-size: 16pt;
@@ -76,6 +76,7 @@
         height: 90%;
         margin: auto;
         background-color: $darkblue;
+        overflow-y: auto;
         .song-card {
           width: 89%;
           height: 15%;
@@ -116,4 +117,13 @@
       }
     }
   }
+}
+
+.songs-container::-webkit-scrollbar { // hides scrollbar on chrome, safari, and opera
+  display: none;
+}
+
+.songs-container { // hides scrollbar on IE, edge, andfirefox
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
 }

--- a/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
+++ b/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
@@ -65,7 +65,34 @@
             transition: 0.2s;
             &:hover {
               background-color: #3BE376;
-              outline: 1px solid $spotify;
+              outline: 2px solid $spotify;
+              box-shadow: none;
+            }
+          }
+        }
+        .show-again-button-container {
+          width: 100%;
+          display: flex;
+          color: $black;
+          // background-color: orange;
+          .show-again-btn {
+            width: 50%;
+            height: fit-content;
+            font-size: 14pt;
+            text-align: center;
+            text-decoration: none;
+            color: $black;
+            margin: 6% auto;
+            margin-top: 0;
+            padding: 1.5em 1.7em;
+            background-color: $bandcamp;
+            border-radius: 3em;
+            box-shadow: -4px 4px 5px rgba(0, 0, 0, 0.3);
+            transition: 0.2s;
+            &:hover {
+              background-color: #9F2D71;
+              color: white;
+              outline: 2px solid #ff76fd;
               box-shadow: none;
             }
           }
@@ -113,6 +140,7 @@
             img {
               width: 100%;
               height: 100%;
+              object-fit: cover;
             }
           }
           .song-info-container {

--- a/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
+++ b/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
@@ -8,36 +8,112 @@
     width: 70%;
     height: 78%;
     margin: auto;
-    background-color: white;
+    // background-color: white;
     display: flex;
     justify-content: space-between;
     .text-wrapper {
       width: 50%;
       height: 100%;
-      background-color: blue;
-      .show-title {
+      // background-color: blue;
+      display: flex;
+      align-items: center;
+      .text-container {
+        height: fit-content;
         width: 100%;
-        height: 10%;
-        color: black;
-        background-color: green;
-      }
-      .show-explanation {
-        width: 100%;
-        height: 40%;
-        color: black;
-        background-color: yellow;
-      }
-      .show-spotify-btn {
-        width: 100%;
-        height: 20%;
-        color: black;
-        background-color: orange;
+        // background-color: purple;
+        .show-title {
+          width: 100%;
+          height: fit-content;
+          color: $black;
+          font-size: 20pt;
+          text-align: center;
+          // background-color: green;
+          h2 {
+            margin-bottom: 0.1em;
+          }
+        }
+        .show-explanation {
+          height: fit-content;
+          margin: 0;
+          padding: 5%;
+          color: $black;
+          text-align: center;
+          font-size: 16pt;
+          // background-color: yellow;
+          p {
+            margin: 0;
+            padding: 0;
+          }
+        }
+        .show-spotify-button-container {
+          width: 100%;
+          display: flex;
+          color: $black;
+          // background-color: orange;
+          .show-spotify-btn {
+            width: 50%;
+            height: fit-content;
+            font-size: 14pt;
+            text-align: center;
+            text-decoration: none;
+            color: $black;
+            margin: 6% auto;
+            padding: 1.5em 1.7em;
+            background-color: $spotify;
+            border-radius: 3em;
+          }
+        }
       }
     }
-    .songs-container {
+    .songs-wrapper {
       width: 50%;
       height: 100%;
-      background-color: red;
+      // background-color: red;
+      display: flex;
+      align-items: center;
+      .songs-container {
+        width: 90%;
+        height: 90%;
+        margin: auto;
+        background-color: $darkblue;
+        .song-card {
+          width: 89%;
+          height: 15%;
+          margin: 4% auto;
+          padding: 1.5%;
+          background-color: #d9d9d9;
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          .song-art-container {
+            width: 20%;
+            height: 100%;
+            // float: left;
+            // background-color: green;
+            img {
+              width: 100%;
+              height: 100%;
+            }
+          }
+          .song-info-container {
+            width: 80%;
+            height: 90%;
+            padding: 0.5em 0 0.5em 0.5em;
+            .song-info {
+              width: 100%;
+              height: 100%;
+              display: flex;
+              flex-direction: column;
+              justify-content: space-between;
+              p {
+                font-size: 10pt;
+                margin: 0 0 0.2em 0;
+                padding: 0;
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
+++ b/app/assets/stylesheets/pagesStyling/_show_scrapelist.scss
@@ -78,6 +78,10 @@
         background-color: $darkblue;
         border-radius: 0.5em;
         overflow-y: auto;
+        .song-card-link-wrapper {
+          text-decoration: none;
+          color: $black;
+        }
         .song-card {
           width: 89%;
           height: 15%;

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,7 +9,7 @@ class PagesController < ApplicationController
     url += '&response_type=code'
     url += '&redirect_uri=http://127.0.0.1:3000/scrapelist/choice_page'
     url += '&show_dialog=true'
-    url += '&scope=playlist-modify-private'
+    url += '&scope=playlist-modify-public playlist-modify-private'
     redirect_to url, allow_other_host: true
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,7 +9,7 @@ class PagesController < ApplicationController
     url += '&response_type=code'
     url += '&redirect_uri=http://127.0.0.1:3000/scrapelist/choice_page'
     url += '&show_dialog=true'
-    url += '&scope=playlist-read-private'
+    url += '&scope=playlist-modify-private'
     redirect_to url, allow_other_host: true
   end
 end

--- a/app/controllers/scrapelistprompts_controller.rb
+++ b/app/controllers/scrapelistprompts_controller.rb
@@ -8,14 +8,14 @@ class ScrapelistpromptsController < ApplicationController
     @scrapelists = Scrapelistprompt.all
   end
 
-  def show
+  def show # if the scraping isn't happening, lines 17 and 18 may be commented out!
     # finding the scrapelistprompt by id
     @scrapelist = Scrapelistprompt.find(params[:id])
     # getting the url created
     url_page_one = @scrapelist.bandcamp_query
     url_page_two = @scrapelist.query_two
-    # scrape_bandcamp(url_page_one) # two lines commented out while styling
-    # scrape_bandcamp(url_page_two)
+    scrape_bandcamp(url_page_one) # two functions for scraping
+    scrape_bandcamp(url_page_two)
     # create an instance variable where we can access the songs
     @songs = Song.where(scrapelistprompt_id: @scrapelist.id)
   end

--- a/app/controllers/scrapelistprompts_controller.rb
+++ b/app/controllers/scrapelistprompts_controller.rb
@@ -94,12 +94,14 @@ class ScrapelistpromptsController < ApplicationController
       album = html_doc.at_css('.detail-album').content
       title = html_doc.at_css('.title').content
       art = html_doc.at_css('.detail-art').attribute('href')
+      link = html_doc.at_css('.detail-album').children.attribute('href')
       # create a song object and save it to the database
       song = Song.new
       song[:title] = title
       song[:album] = album
       song[:artist] = artist
       song[:album_art] = art
+      song[:music_link] = link
       song[:scrapelistprompt_id] = @scrapelist.id
       song.save!
     end

--- a/app/controllers/scrapelistprompts_controller.rb
+++ b/app/controllers/scrapelistprompts_controller.rb
@@ -14,8 +14,8 @@ class ScrapelistpromptsController < ApplicationController
     # getting the url created
     url_page_one = @scrapelist.bandcamp_query
     url_page_two = @scrapelist.query_two
-    scrape_bandcamp(url_page_one)
-    scrape_bandcamp(url_page_two)
+    # scrape_bandcamp(url_page_one) # two lines commented out while styling
+    # scrape_bandcamp(url_page_two)
     # create an instance variable where we can access the songs
     @songs = Song.where(scrapelistprompt_id: @scrapelist.id)
   end

--- a/app/views/graveyard.html.erb
+++ b/app/views/graveyard.html.erb
@@ -44,3 +44,18 @@
     <%= label_tag(:genre_world, "World") %>
     <%= submit_tag("Submit") %>
   <% end %> --->
+
+
+<!-- scrapelist#show
+<div class="song-card">
+  <div class="song-art-container">
+    <img src="https://upload.wikimedia.org/wikipedia/en/5/54/AphexTwinICareBecauseYouDo.jpg" alt="placeholder">
+  </div>
+  <div class="song-info-container">
+    <div class="song-info">
+      <p>Artist: Aphex Twin</p>
+      <p>Song: I Care Because You Do</p>
+      <p>Album: Selected Ambient Works Volume II</p>
+    </div>
+  </div>
+</div> -->

--- a/app/views/scrapelistprompts/show.html.erb
+++ b/app/views/scrapelistprompts/show.html.erb
@@ -6,7 +6,7 @@
           <h2>Heres what we got for <%= @scrapelist.genre %>:</h2>
         </div>
         <div class="show-explanation">
-          <p>Have a scroll on the right and click to check out the tracks we got from Bandcamp. Please keep in mind not every song that is on Bandcamp is on Spotify, so what is shown here may not completely resemble what you will see in your Spotify playlist</p>
+          <p>Have a scroll on the right and click to check out the tracks we got from Bandcamp. Please keep in mind that not every song that is on Bandcamp is on Spotify, so what is shown here may not completely resemble what you will see in your Spotify playlist</p>
         </div>
         <div class="show-spotify-button-container">
           <%= link_to "Click to create your Spotify playlist!", send_to_spotify_path, class: "show-spotify-btn" %>

--- a/app/views/scrapelistprompts/show.html.erb
+++ b/app/views/scrapelistprompts/show.html.erb
@@ -8,12 +8,26 @@
         <div class="show-explanation">
           <p>Have a scroll on the right through the tracks we got from Bandcamp, keep in mind that not every song on Bandcamp is on Spotify so what is shown here may not completely resemble what you will see in your Spotify playlist</p>
         </div>
-        <div class="spotify-button">
-          <%= link_to "Create Spotify Playlist", send_to_spotify_path, class: "show-spotify-btn" %>
+        <div class="show-spotify-button-container">
+          <%= link_to "Click to create your Spotify playlist!", send_to_spotify_path, class: "show-spotify-btn" %>
         </div>
       </div>
     </div>
-    <div class="songs-container">
+    <div class="songs-wrapper">
+      <div class="songs-container">
+        <div class="song-card">
+          <div class="song-art-container">
+            <img src="https://upload.wikimedia.org/wikipedia/en/5/54/AphexTwinICareBecauseYouDo.jpg" alt="placeholder">
+          </div>
+          <div class="song-info-container">
+            <div class="song-info">
+              <p>Artist: Aphex Twin</p>
+              <p>Song: I Care Because You Do</p>
+              <p>Album: Selected Ambient Works Volume II</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
  </div>

--- a/app/views/scrapelistprompts/show.html.erb
+++ b/app/views/scrapelistprompts/show.html.erb
@@ -6,7 +6,7 @@
           <h2>Heres what we got for <%= @scrapelist.genre %>:</h2>
         </div>
         <div class="show-explanation">
-          <p>Have a scroll on the right through the tracks we got from Bandcamp, keep in mind that not every song on Bandcamp is on Spotify so what is shown here may not completely resemble what you will see in your Spotify playlist</p>
+          <p>Have a scroll on the right and click to check out the tracks we got from Bandcamp. Please keep in mind not every song that is on Bandcamp is on Spotify, so what is shown here may not completely resemble what you will see in your Spotify playlist</p>
         </div>
         <div class="show-spotify-button-container">
           <%= link_to "Click to create your Spotify playlist!", send_to_spotify_path, class: "show-spotify-btn" %>
@@ -16,18 +16,20 @@
     <div class="songs-wrapper">
       <div class="songs-container">
         <% @songs.each do |s| %>
-          <div class="song-card">
-            <div class="song-art-container">
-              <%= image_tag s.album_art %>
-            </div>
-            <div class="song-info-container">
-              <div class="song-info">
-                <p>Artist: <strong><%= s.artist %></strong></p>
-                <p>Song: <strong><%= s.title %></strong></p>
-                <p>Album: <strong><%= s.album %></strong></p>
+          <%= link_to s.music_link, target: "_blank", class: "song-card-link-wrapper" do %>
+            <div class="song-card">
+              <div class="song-art-container">
+                <%= image_tag s.album_art %>
+              </div>
+              <div class="song-info-container">
+                <div class="song-info">
+                  <p>Artist: <strong><%= s.artist %></strong></p>
+                  <p>Song: <strong><%= s.title %></strong></p>
+                  <p>Album: <strong><%= s.album %></strong></p>
+                </div>
               </div>
             </div>
-          </div>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/scrapelistprompts/show.html.erb
+++ b/app/views/scrapelistprompts/show.html.erb
@@ -1,4 +1,31 @@
-<h1>Bandcamp url produced:</h1>
+ <div class="show-wrapper">
+  <div class="show-container">
+    <div class="text-wrapper">
+      <div class="text-container">
+        <div class="show-title">
+          <h2>Heres what we got:</h2>
+        </div>
+        <div class="show-explanation">
+          <p>Have a scroll on the right through the tracks we got from Bandcamp, keep in mind that not every song on Bandcamp is on Spotify so what is shown here may not completely resemble what you will see in your Spotify playlist</p>
+        </div>
+        <div class="spotify-button">
+          <%= link_to "Create Spotify Playlist", send_to_spotify_path, class: "show-spotify-btn" %>
+        </div>
+      </div>
+    </div>
+    <div class="songs-container">
+    </div>
+  </div>
+ </div>
+
+
+
+
+
+
+
+
+<!-- <h1>Bandcamp url produced:</h1>
 <p><%= @scrapelist.bandcamp_query %></p>
 <p><%= @scrapelist.query_two %></p>
 <br>
@@ -9,4 +36,4 @@
   <p>Song: <%= s.title %></p>
   <p>Album: <%= s.album %></p>
   <br>
-<% end %>
+<% end %> -->

--- a/app/views/scrapelistprompts/show.html.erb
+++ b/app/views/scrapelistprompts/show.html.erb
@@ -11,6 +11,9 @@
         <div class="show-spotify-button-container">
           <%= link_to "Click to create your Spotify playlist!", send_to_spotify_path, class: "show-spotify-btn" %>
         </div>
+        <div class="show-again-button-container">
+          <%= link_to "Create another Scrapelist!", choice_page_path, class: "show-again-btn" %>
+        </div>
       </div>
     </div>
     <div class="songs-wrapper">

--- a/app/views/scrapelistprompts/show.html.erb
+++ b/app/views/scrapelistprompts/show.html.erb
@@ -3,7 +3,7 @@
     <div class="text-wrapper">
       <div class="text-container">
         <div class="show-title">
-          <h2>Heres what we got:</h2>
+          <h2>Heres what we got for <%= @scrapelist.genre %>:</h2>
         </div>
         <div class="show-explanation">
           <p>Have a scroll on the right through the tracks we got from Bandcamp, keep in mind that not every song on Bandcamp is on Spotify so what is shown here may not completely resemble what you will see in your Spotify playlist</p>
@@ -15,18 +15,20 @@
     </div>
     <div class="songs-wrapper">
       <div class="songs-container">
-        <div class="song-card">
-          <div class="song-art-container">
-            <img src="https://upload.wikimedia.org/wikipedia/en/5/54/AphexTwinICareBecauseYouDo.jpg" alt="placeholder">
-          </div>
-          <div class="song-info-container">
-            <div class="song-info">
-              <p>Artist: Aphex Twin</p>
-              <p>Song: I Care Because You Do</p>
-              <p>Album: Selected Ambient Works Volume II</p>
+        <% @songs.each do |s| %>
+          <div class="song-card">
+            <div class="song-art-container">
+              <%= image_tag s.album_art %>
+            </div>
+            <div class="song-info-container">
+              <div class="song-info">
+                <p>Artist: <strong><%= s.artist %></strong></p>
+                <p>Song: <strong><%= s.title %></strong></p>
+                <p>Album: <strong><%= s.album %></strong></p>
+              </div>
             </div>
           </div>
-        </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
   get 'scrapelist/choice_page', to: 'scrapelistprompts#choose', as: 'choice_page'
   get 'scrapelist/new_easy', to: 'scrapelistprompts#new_easy', as: 'new_scrapelist_easy'
   post 'scrapelist/new_easy', to: 'scrapelistprompts#create_easy', as: 'scrapelistprompts'
+  post 'scrapelist/send_to_spotify', to: 'scrapelistprompts#send_to_spotify', as: 'send_to_spotify'
 end

--- a/db/migrate/20230404041053_add_music_link_to_songs.rb
+++ b/db/migrate/20230404041053_add_music_link_to_songs.rb
@@ -1,0 +1,5 @@
+class AddMusicLinkToSongs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :songs, :music_link, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_04_012012) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_04_041053) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,6 +39,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_04_012012) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "album_art"
+    t.string "music_link"
     t.index ["scrapelistprompt_id"], name: "index_songs_on_scrapelistprompt_id"
   end
 


### PR DESCRIPTION
Created and styled the show page for a scrapelist to be shown to a user after its been scraped from bandcamp, but before its sent to spotify to be turned into a playlist. Added some migrations to add extra functionality like being able to click each bandcamp song shown and being taken to the bandcamp page where it lives, as well as saving to the song model a link to an image of the album cover. 