### PR TITLE
New turnaround page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,3 +19,4 @@ $spotify: #1FD760;
 @import 'pagesStyling/easy_genre_form';
 @import 'pagesStyling/picky_genre_form';
 @import 'pagesStyling/show_scrapelist';
+@import 'pagesStyling/send_to_spotify';

--- a/app/assets/stylesheets/pagesStyling/_send_to_spotify.scss
+++ b/app/assets/stylesheets/pagesStyling/_send_to_spotify.scss
@@ -1,0 +1,50 @@
+.send-to-spotify-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  width: 100vw;
+  background-color: #511639;
+  .send-to-spotify-container {
+    // background-color: blue;
+    color: white;
+    text-align: center;
+    padding: 20px;
+    line-height: 2.6em;
+    .show-spotify-btn {
+      background-color: $spotify;
+      font-size: 14pt;
+      text-align: center;
+      text-decoration: none;
+      color: $black;
+      margin: 10px;
+      padding: 0.9em 1.7em;
+      border-radius: 3em;
+      box-shadow: -4px 4px 5px rgba(0, 0, 0, 0.3);
+      transition: 0.2s;
+      &:hover {
+        background-color: #3BE376;
+        outline: 2px solid $spotify;
+        box-shadow: none;
+      }
+    }
+    .start-again-btn {
+      background-color: $pink;
+      font-size: 14pt;
+      text-align: center;
+      text-decoration: none;
+      color: $black;
+      margin: 10px;
+      padding: 0.9em 1.7em;
+      border-radius: 3em;
+      box-shadow: -4px 4px 5px rgba(0, 0, 0, 0.3);
+      transition: 0.2s;
+      &:hover {
+        background-color: $bandcamp;
+        outline: 2px solid $spotify;
+        box-shadow: none;
+      }
+    }
+  }
+}

--- a/app/controllers/scrapelistprompts_controller.rb
+++ b/app/controllers/scrapelistprompts_controller.rb
@@ -89,15 +89,24 @@ class ScrapelistpromptsController < ApplicationController
 
   def send_to_spotify
     # create instance variables to store the current scrapelist and the songs which are in it
+    # puts 'getting scrapelist'
     @scrapelist = Scrapelistprompt.find(params[:id])
+    # puts 'getting songs'
     @songs = Song.where(scrapelistprompt_id: params[:id])
     # array of songs found with spotify search
+    # puts 'grabbing song URIs'
     spotify_uris = grab_song_URIs(@songs)
     # create a new playlist, then populate it with the songs
+    # puts 'creating new playlist'
     new_playlist = create_spotify_playlist(@scrapelist.genre)
+    # puts 'populating playlist'
+    populate_playlist_response_code = populate_new_playlist(new_playlist[:playlist_id], spotify_uris)
+    @playlist_link = new_playlist[:external_url]
     # if statement to catch failure
-    if populate_new_playlist(new_playlist[:playlist_id], spotify_uris) == 201
-      redirect_to new_playlist[:external_url], allow_other_host: true
+    # puts 'redirecting'
+    if populate_playlist_response_code == 201
+      # redirect_to new_playlist[:external_url], allow_other_host: true
+      @status = 'success'
     else
       render :show, status: :unprocessable_entity
     end

--- a/app/views/scrapelistprompts/send_to_spotify.html.erb
+++ b/app/views/scrapelistprompts/send_to_spotify.html.erb
@@ -1,0 +1,8 @@
+<div class="send-to-spotify-wrapper">
+  <div class="send-to-spotify-container">
+    <h1>The Scrapelist creation was a Success<%#= @status %>!</h1>
+    <%= link_to "Click here to see it!", @playlist_link, target: "_blank", class: "show-spotify-btn" %>
+    <!-- <a target="_blank" class="show-spotify-btn" href="/">Click here to see it!</a> -->
+    <%= link_to "Create another Scrapelist", login_path, class: "start-again-btn" %>
+  </div>
+</div>


### PR DESCRIPTION
Had issues with the external redirect in the send_to_spotify action, created a turnaround page instead which lists an option to go see the new playlist on spotify, or create another scrapelist instead which goes back to the spotify login action